### PR TITLE
use https to find IP address

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,5 +12,6 @@ sed -i \
 	-e "s/auth_key=.*/auth_key=\"$CF_API\"/g" \
 	-e "s/zone_name=.*/zone_name=\"$ZONE\"/g" \
 	-e "s/record_name=.*/record_name=\"$CF_HOST\"/g" \
+	-e "s=http://ipv4.icanhazip.com=https://ipv4.icanhazip.com=g" \
 	/cloudflare-update-record.sh
 /cloudflare-update-record.sh


### PR DESCRIPTION
My ISP is Comcast, and they inject data usage warnings via an http proxy. This caused my DDNS to update to Comcast's IP address, and all my outward facing services to go down. This [reddit thread](https://www.reddit.com/r/homelab/comments/5njlmh/comcast_data_usage_proxy/) has a discussion. 

This pull request is to switch to https for collecting the current IP address to as to avoid this issue. 